### PR TITLE
Improved display of partial transcriptions

### DIFF
--- a/speechmatics/cli.py
+++ b/speechmatics/cli.py
@@ -30,17 +30,17 @@ class CursesInterface():
         self.win.clear()
         self.win.refresh()
 
-        self.y, self.x = self.win.getyx()
+        self.cursor_y, self.cursor_x = self.win.getyx()
 
     def print_partial(self, text):
-        self.win.addstr(self.y, self.x, text, curses.A_UNDERLINE)
+        self.win.addstr(self.cursor_y, self.cursor_x, text, curses.A_UNDERLINE)
         self.win.refresh()
 
     def print_final(self, text):
-        self.win.addstr(self.y, self.x, text)
+        self.win.addstr(self.cursor_y, self.cursor_x, text)
         self.win.refresh()
 
-        self.y, self.x = self.win.getyx()
+        self.cursor_y, self.cursor_x = self.win.getyx()
 
     def __del__(self):
         curses.endwin()


### PR DESCRIPTION
Displays partial transcriptions in a more intuitive way. Partial transcriptions are underlined.

![output](https://user-images.githubusercontent.com/5170829/73281853-7f2b8c80-41e8-11ea-9729-2ba04cf47ddf.gif)

This is an improvement on the `\r` approach which repeatedly printed same lines if it exceeded the terminal width.