### PR TITLE
Remove client-side checks for invalid or empty audio

### DIFF
--- a/speechmatics/client.py
+++ b/speechmatics/client.py
@@ -49,9 +49,6 @@ async def read_in_chunks(stream, chunk_size):
         a multiple of max_sample_size
 
     """
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be > 0")
-
     count = 0
     while True:
         # Work with both async and synchronous file readers.
@@ -61,8 +58,6 @@ async def read_in_chunks(stream, chunk_size):
             audio_chunk = stream.read(chunk_size)
 
         if not audio_chunk:
-            if count == 0:
-                raise ValueError("Audio stream is empty")
             break
         yield audio_chunk
         count += 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,22 +61,11 @@ async def test_read_in_chunks():
 
     stream = io.BytesIO(bytes(range(5)))
 
-    gen = client.read_in_chunks(stream, 0)
-    with pytest.raises(ValueError):
-        await gen.__anext__()
-
     gen = client.read_in_chunks(stream, 2)
     assert await gen.__anext__() == b"\x00\x01"
     assert await gen.__anext__() == b"\x02\x03"
     assert await gen.__anext__() == b"\x04"
     with pytest.raises(StopAsyncIteration):
-        await gen.__anext__()
-
-
-@pytest.mark.asyncio
-async def test_read_in_chunks_rejects_an_empty_stream():
-    gen = client.read_in_chunks(io.BytesIO(), 1)
-    with pytest.raises(ValueError):
         await gen.__anext__()
 
 


### PR DESCRIPTION
These checks are handled on the server-side.

Part of REQ-11165