### PR TITLE
Improve upload speed when posting files to batch api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improve upload speeds for files submitted with the batch client
+
 ## [1.11.0] - 2023-08-25
 
 ### Added

--- a/speechmatics/batch_client.py
+++ b/speechmatics/batch_client.py
@@ -223,28 +223,39 @@ class BatchClient:
             )
 
         # If audio=None, fetch_data must be specified
-        if audio and "fetch_data" in config_dict:
-            raise ValueError("Only one of audio or fetch_data can be set at a time")
-        if not audio and "fetch_data" in config_dict:
-            audio_data = None
-        elif isinstance(audio, (str, os.PathLike)):
-            with Path(audio).expanduser().open("rb") as file:
-                audio_data = os.path.basename(file.name), file.read()
-        elif isinstance(audio, tuple) and "fetch_data" not in config_dict:
-            audio_data = audio
-        else:
-            raise ValueError("Audio must be a filepath or a tuple of (filename, bytes)")
+        file_object = None
+        try:
+            if audio and "fetch_data" in config_dict:
+                raise ValueError("Only one of audio or fetch_data can be set at a time")
+            if not audio and "fetch_data" in config_dict:
+                audio_data = None
+            elif isinstance(audio, (str, os.PathLike)):
+                # httpx performance is better when using a file-like object
+                # compared to passing the file contents as bytes.
+                file_object = Path(audio).expanduser().open("rb")
+                audio_data = os.path.basename(file_object.name), file_object
+            elif isinstance(audio, tuple) and "fetch_data" not in config_dict:
+                audio_data = audio
+            else:
+                raise ValueError(
+                    "Audio must be a filepath or a tuple of (filename, bytes)"
+                )
 
-        # httpx seems to expect an un-nested json, throws a type error otherwise.
-        config_data = {"config": json.dumps(config_dict, ensure_ascii=False)}
+            # httpx seems to expect an un-nested json, throws a type error otherwise.
+            config_data = {"config": json.dumps(config_dict, ensure_ascii=False)}
 
-        if audio_data:
-            audio_file = {"data_file": audio_data}
-        else:
-            audio_file = _ForceMultipartDict()
+            if audio_data:
+                audio_file = {"data_file": audio_data}
+            else:
+                audio_file = _ForceMultipartDict()
 
-        response = self.send_request("POST", "jobs", data=config_data, files=audio_file)
-        return response.json()["id"]
+                response = self.send_request(
+                    "POST", "jobs", data=config_data, files=audio_file
+                )
+                return response.json()["id"]
+        finally:
+            if file_object:
+                file_object.close()
 
     def submit_jobs(
         self,

--- a/speechmatics/batch_client.py
+++ b/speechmatics/batch_client.py
@@ -249,10 +249,10 @@ class BatchClient:
             else:
                 audio_file = _ForceMultipartDict()
 
-                response = self.send_request(
-                    "POST", "jobs", data=config_data, files=audio_file
-                )
-                return response.json()["id"]
+            response = self.send_request(
+                "POST", "jobs", data=config_data, files=audio_file
+            )
+            return response.json()["id"]
         finally:
             if file_object:
                 file_object.close()


### PR DESCRIPTION
When sending multipart file uploads using httpx it's [recommended](https://www.python-httpx.org/advanced/#multipart-file-encoding) to pass a file-like object. Upload speeds improve substantially by doing so. Also we benefit from not loading the whole file in memory.