### PR TITLE
Turn 'pyannote' into an optional dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pip3 install -r requirements.txt -r requirements-dev.txt
+      run: pip3 install -r requirements.txt -r requirements-dev.txt -r requirements-metrics.txt
 
     - name: Lint
       run: make lint

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ To install from PyPI:
 ```bash
 pip install speechmatics-python
 ```
+
+To use the sm-metrics tool for diarization features and speaker identification metrics, install with the optional dependencies:
+```bash
+pip install speechmatics-python[metrics]
+```
 To install from source:
 ```bash
 git clone https://github.com/speechmatics/speechmatics-python

--- a/asr_metrics/cli.py
+++ b/asr_metrics/cli.py
@@ -1,34 +1,74 @@
 """Entrypoint for SM metrics"""
 
 import argparse
+import sys
 
-import asr_metrics.diarization.sm_diarization_metrics.cookbook as diarization_metrics
-import asr_metrics.wer.__main__ as wer_metrics
+try:
+    import asr_metrics.wer.__main__ as wer_metrics
+
+    WER_AVAILABLE = True
+except ImportError:
+    WER_AVAILABLE = False
+
+try:
+    import asr_metrics.diarization.sm_diarization_metrics.cookbook as diarization_metrics
+
+    DIARIZATION_AVAILABLE = True
+except ImportError:
+    DIARIZATION_AVAILABLE = False
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Your CLI description")
+    parser = argparse.ArgumentParser(
+        description="Speechmatics metrics tool for WER and diarization"
+    )
 
     # Create subparsers
     subparsers = parser.add_subparsers(
         dest="mode", help="Metrics mode. Choose from 'wer' or 'diarization'"
     )
-    subparsers.required = True  # Make sure a subparser id always provided
+    subparsers.required = True  # Make sure a subparser is always provided
 
-    wer_parser = subparsers.add_parser("wer", help="Entrypoint for WER metrics")
-    wer_metrics.get_wer_args(wer_parser)
+    if WER_AVAILABLE:
+        wer_parser = subparsers.add_parser("wer", help="Entrypoint for WER metrics")
+        wer_metrics.get_wer_args(wer_parser)
+    else:
+        wer_parser = subparsers.add_parser(
+            "wer", help="Entrypoint for WER metrics (requires additional dependencies)"
+        )
 
-    diarization_parser = subparsers.add_parser(
-        "diarization", help="Entrypoint for diarization metrics"
-    )
-    diarization_metrics.get_diarization_args(diarization_parser)
+    if DIARIZATION_AVAILABLE:
+        diarization_parser = subparsers.add_parser(
+            "diarization", help="Entrypoint for diarization metrics"
+        )
+        diarization_metrics.get_diarization_args(diarization_parser)
+    else:
+        diarization_parser = subparsers.add_parser(
+            "diarization",
+            help="Entrypoint for diarization metrics (requires pyannote dependencies)",
+        )
+        diarization_parser.add_argument(
+            "--help-install",
+            action="store_true",
+            help="Show instructions for installing diarization dependencies",
+        )
 
     args = parser.parse_args()
 
     if args.mode == "wer":
-        wer_metrics.main(args)
+        if WER_AVAILABLE:
+            wer_metrics.main(args)
+        else:
+            print("Error: WER metrics require additional dependencies.")
+            print("Please install them with: pip install speechmatics-python[metrics]")
+            sys.exit(1)
     elif args.mode == "diarization":
-        diarization_metrics.main(args)
+        if DIARIZATION_AVAILABLE:
+            diarization_metrics.main(args)
+        else:
+            print("Error: Diarization metrics require additional dependencies.")
+            print("Please install them with: pip install speechmatics-python[metrics]")
+            sys.exit(1)
     else:
         print("Unsupported mode. Please use 'wer' or 'diarization'")
 

--- a/requirements-metrics.txt
+++ b/requirements-metrics.txt
@@ -1,0 +1,8 @@
+docopt
+jiwer
+more-itertools
+pandas
+pyannote.core
+pyannote.database
+regex
+tabulate>=0.8.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,3 @@ httpx[http2]~=0.23
 polling2~=0.5
 toml~=0.10.2
 tenacity~=8.2.3
-jiwer
-regex
-more-itertools
-pyannote.core
-pyannote.database
-docopt
-tabulate>=0.8.9

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=read_list("requirements.txt"),
     tests_require=read_list("requirements-dev.txt"),
+    extras_require={
+        "metrics": read_list("requirements-metrics.txt"),
+    },
     entry_points={
         "console_scripts": [
             "speechmatics = speechmatics.cli:main",


### PR DESCRIPTION
The current dependency on pyannote significantly increases the installation timeand complexity for speechmatics-python. Specifically, pyannote introduces heavy dependencies (numpy, scipy, and others), which, when built from source, require extensive build times and additional tooling, including a Fortran compiler \o/

    ├── speechmatics-python v3.0.4
    │   ├── docopt v0.6.2
    │   ├── httpx[http2] v0.28.1 (*)
    │   ├── jiwer v3.1.0
    │   │   ├── click v8.1.8
    │   │   └── rapidfuzz v3.13.0
    │   ├── more-itertools v10.7.0
    │   ├── polling2 v0.5.0
    │   ├── pyannote-core v5.0.0
    │   │   ├── numpy v2.2.5
    │   │   ├── scipy v1.15.3
    │   │   │   └── numpy v2.2.5
    │   │   ├── sortedcontainers v2.4.0
    │   │   └── typing-extensions v4.13.2
    │   ├── pyannote-database v5.1.3
    │   │   ├── pandas v2.2.3
    │   │   │   ├── numpy v2.2.5
    │   │   │   ├── python-dateutil v2.9.0.post0
    │   │   │   │   └── six v1.17.0
    │   │   │   ├── pytz v2025.2
    │   │   │   └── tzdata v2025.2
    │   │   ├── pyannote-core v5.0.0 (*)
    │   │   ├── pyyaml v6.0.2
    │   │   └── typer v0.15.3
    │   │       ├── click v8.1.8
    │   │       ├── rich v14.0.0
    │   │       │   ├── markdown-it-py v3.0.0
    │   │       │   │   └── mdurl v0.1.2
    │   │       │   └── pygments v2.19.1
    │   │       ├── shellingham v1.5.4
    │   │       └── typing-extensions v4.13.2
    │   ├── regex v2024.11.6
    │   ├── tabulate v0.9.0
    │   ├── tenacity v8.2.3
    │   ├── toml v0.10.2
    │   └── websockets v14.2

Since the pyannote dependency is only used within the asr_metrics module and does not appear necessary for typical usage scenarios of the SDK, making it optional would greatly streamline default installations 😅

So, I tried to make it optional and edited the asr_metrics cli to handle the case when it is missing (and made some tiny fixes).