### PR TITLE
Move channel field into root of AddTranscript

### DIFF
--- a/speechmatics/cli.py
+++ b/speechmatics/cli.py
@@ -590,10 +590,7 @@ def add_printing_handlers(
         transcripts.text += plaintext
 
     def get_channel(message):
-        return next(
-            (result["channel"] for result in message["results"] if "channel" in result),
-            None,
-        )
+        return message.get("channel", None)
 
     def audio_event_handler(message):
         if print_json:


### PR DESCRIPTION
Apologies for being back at it again. 

When testing multichannel internally, I noticed that many people instinctively looked for the `channel` field within the root or metadata of the `AddTranscript` message.  Right now, `channel` is in both the results and metadata object. This change will mean the Python client will look for it in just the root of the message.

Accompanying change for this can be found in GitLab:
https://gitlab1.speechmatics.io/aml/aladdin/-/merge_requests/10861